### PR TITLE
Reset sum to 0 for invalid form

### DIFF
--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -48,9 +48,7 @@ export class RoundInputComponent implements OnInit {
     })
     
     roundFormGroup.statusChanges.subscribe(data => {
-      if (data === 'VALID') {
-        this.calcScoreDifferential()
-      }
+      this.calcScoreDifferential();
     })
 
     return roundFormGroup
@@ -62,11 +60,18 @@ export class RoundInputComponent implements OnInit {
 
     let eighteeenHoleScore;
     let nineHoleScore;
+    let total;
 
     this.roundInputs.controls.forEach((control) => {
-      eighteeenHoleScore = control.get('eighteenHoleScore')?.value
-      nineHoleScore = control.get('nineHoleScore')?.value
-      this.roundTotal.push(eighteeenHoleScore + nineHoleScore)
+      if (control.status === 'VALID') {
+        eighteeenHoleScore = control.get('eighteenHoleScore')?.value
+        nineHoleScore = control.get('nineHoleScore')?.value
+        total = eighteeenHoleScore + nineHoleScore
+        this.roundTotal.push(total)
+      } else {
+        total = 0;
+        this.roundTotal.push(total)
+      }
     })
   }
 


### PR DESCRIPTION
Removed check for valid on the statusChange because you can get the status in the roundInputs.controls.forEach().  In the loop looked at the status and if it was valid then do the math and push it into the array, if it's not valid make the total 0 and push 0 to that specific index in the array.

This way you can set the value to 0 for any formGroup without affecting any of the other valid formGroups

In the future I will tie the invalid form groups that display 0 with some sort of validation message saying they need to enter valid numbers before a total will display