### PR TITLE
Update calculate handicap functionality

### DIFF
--- a/src/app/round-input/round-input.component.html
+++ b/src/app/round-input/round-input.component.html
@@ -63,7 +63,7 @@
         <!-- button needs to stay within form for validation to fire -->
         <!-- button is grayed out/disabled if the form isn't valid -->
         <!-- In the future, this button should be grayed out IF the first 3 groupings are invalid -->
-        <button (click)='calculateHandicapBtnClick()'>Calculate Handicap</button>
+        <button (click)='calculateHandicapBtnClick()' [disabled]="!roundForm.valid" >Calculate Handicap</button>
 
         <!-- <button (click)='calculateHandicapBtnClick()' [disabled]="!roundForm.valid">Calculate Handicap</button> -->
 


### PR DESCRIPTION
Btn to calculate handicap is disabled until the form is entirely valid.  This also addresses when a user does a calculation, then adds a row the btn becomes disabled because the form is 'invalid' due to the new row.  Once that new row is filled out and the entire form is valid again the btn becomes enabled