### PR TITLE
Refactor round input

### DIFF
--- a/src/app/round-input/round-input.component.html
+++ b/src/app/round-input/round-input.component.html
@@ -11,35 +11,36 @@
                 </div>
 
                 <!-- 9 or 18 hole selection -->
-                <div class="form-group">
-                    <label>Round Selection: </label>
-                    <div>
-                        <label attr.for="{{'nineHoles' + roundCount}}">
-                            <input type="radio"
-                            id="{{'nineHoles' + roundCount}}"
-                            [value]=9
-                            formControlName="roundSelection">
-                            9 Holes
-                        </label>
+                <ng-container formGroupName="roundSelectionGroup">
+                    <div class="form-group">
+                        <label>Round Selection: </label>
+                        <div>
+                            <label attr.for="{{'nineHoles' + roundCount}}">
+                                <input type="radio"
+                                id="{{'nineHoles' + roundCount}}"
+                                [value]=9
+                                formControlName="roundSelection">
+                                9 Holes
+                            </label>
+                        </div>
+                        <div>
+                            <label attr.for="{{'eighteenHoles' + roundCount}}">
+                                <input type="radio"
+                                id="{{'eighteenHoles' + roundCount}}"
+                                [value]=18 
+                                formControlName="roundSelection">
+                                18 Holes
+                            </label>
+                        </div>
                     </div>
-                    <div>
-                        <label attr.for="{{'eighteenHoles' + roundCount}}">
-                            <input type="radio"
-                            id="{{'eighteenHoles' + roundCount}}"
-                            [value]=18 
-                            formControlName="roundSelection">
-                            18 Holes
-                        </label>
-                    </div>
-                </div>
-
+                </ng-container>
 
                 <!-- round score input -->
                 <div class="form-group">
                     <label attr.for="{{'userRoundScore' + roundCount}}">Round Score: </label>
-                    <input id="{{'userRoundScore' + roundCount}}" type="number" formControlName="userRoundScore" [min]="getMinScore(round.get('roundSelection')?.value)">
+                    <input id="{{'userRoundScore' + roundCount}}" type="number" formControlName="userRoundScore" [min]="getMinScore(round.get('roundSelectionGroup')?.get('roundSelection')?.value)">
                     <br>
-                    <span *ngIf="round.get('userRoundScore')?.errors?.['invalidForm']" style="font-weight: bold; color: red;">Enter in a round of at least {{round.get('roundSelection')?.value === 18 ? '18' : '9'}}</span>
+                    <span *ngIf="round.get('userRoundScore')?.errors?.['invalidForm']" style="font-weight: bold; color: red;">Enter in a round of at least {{round.get('roundSelectionGroup')?.get('roundSelection')?.value === 18 ? '18' : '9'}}</span>
                 </div>
 
                 <!-- course rating input -->

--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, AbstractControl, FormArray, ValidatorFn } from "@angular/forms";
-import { map } from 'rxjs';
 // import { Round } from '../data/user-handicap-modal';
 
 @Component({

--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -12,7 +12,7 @@ export class RoundInputComponent implements OnInit {
 
   // defines form model. Template will bind to this root form model
   roundForm: FormGroup;
-  roundTotal: number[] = [];
+  roundTotal: number[] = [0, 0, 0];
   handicapIndex:  number = 0;
   calcBtnDisabled: boolean = false;
   recalcHandicapMsg: String = 'Handicap needs to be re-calculated'

--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -49,7 +49,11 @@ export class RoundInputComponent implements OnInit {
     roundFormGroup.controls.roundSelectionGroup.controls.roundSelection.valueChanges.subscribe(value => {
       this.handleUserRoundScoreOnRoundSelectionChange(value, index);
     });
-  
+
+    /*
+      Enable calculate handicap btn if user calculates handicap and then makes a changes.  After initial calculation btn is disabled until a value is changed
+      Have the score differential calculated whenever the formGroup value change fires
+    */
     roundFormGroup.valueChanges.subscribe(control => {
       if (control && control.userRoundScore !== null && this.calcBtnDisabled) {
         this.calcBtnDisabled = false;

--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { FormGroup, FormBuilder, Validators, AbstractControl, FormArray, ValidatorFn } from "@angular/forms";
+import { map } from 'rxjs';
 // import { Round } from '../data/user-handicap-modal';
 
 @Component({
@@ -11,15 +12,11 @@ export class RoundInputComponent implements OnInit {
 
   // defines form model. Template will bind to this root form model
   roundForm: FormGroup;
-  roundTotal: number[] = [0, 0, 0];
-  /*
-  remove the below eighteenHoleRoundMin variable in the future since on page load userRoundScore is disabled
-  and selecting a radio button will enable the round and also pass in the correct min
-  */
-  eighteenHoleRoundMin: number = 18;
+  roundTotal: number[] = [];
   handicapIndex:  number = 0;
   calcBtnDisabled: boolean = false;
   recalcHandicapMsg: String = 'Handicap needs to be re-calculated'
+  roundInputsArrayIndex: number = 3; // starts at 3 because the first 3 formGroups are positions 0 - 2
 
   get roundInputsArray(): FormArray{
     return <FormArray>this.roundForm.get('roundInputsArray')
@@ -32,61 +29,66 @@ export class RoundInputComponent implements OnInit {
   ngOnInit(): void {
 
     this.roundForm = this.fb.group({
-      roundInputsArray: this.fb.array([ this.buildRoundForm(), this.buildRoundForm(), this.buildRoundForm() ])
+      roundInputsArray: this.fb.array([ this.buildRoundForm(0), this.buildRoundForm(1), this.buildRoundForm(2) ])
     })
   };
 
-  buildRoundForm() : FormGroup {
+  buildRoundForm(index: number) : FormGroup {
     const roundFormGroup = this.fb.group({
       userRoundScore: [
         {
           value: null, disabled: true
         },
         {
-        validators: [Validators.required, this.roundInputValidation(this.eighteenHoleRoundMin)],
         updateOn: 'change'
       }],
       courseRating: [67.5, [Validators.required]],
       slopeRating: [117, [Validators.required]],
-      roundSelection: [null, [Validators.required]]
+      roundSelectionGroup: this.fb.group({
+        roundSelection: [null, [Validators.required]],
+      })
     });
 
-    // used to dynamically set validation for user round input based on radio button selection
-    roundFormGroup.controls.roundSelection.valueChanges.subscribe(value => {
-      // on radio btn change clear out the values for round score
-      roundFormGroup.controls.userRoundScore.setValue(null)
-
-      if (this.calcBtnDisabled === false) {
-        this.calcBtnDisabled = true
-      }
-
-      if (value === 9 || value === 18) {
-        roundFormGroup.controls.userRoundScore.enable();
-        roundFormGroup.controls.userRoundScore.setValidators([
-          Validators.required,
-          Validators.min(value),
-          this.roundInputValidation(value)
-        ]);
-      }
-    
-      // onlySelf is an optional parameter which only runs updateValueAndValidity for this specific control
-      // since we are only setting validators for userRoundScore we only need to update validation runs for this control
-      roundFormGroup.controls.userRoundScore.updateValueAndValidity({ onlySelf: true });
-    })
+    roundFormGroup.controls.roundSelectionGroup.controls.roundSelection.valueChanges.subscribe(value => {
+      this.handleUserRoundScoreOnRoundSelectionChange(value, index);
+    });
   
-    // enable calculate handicap btn if user calculates handicap and then makes a changes.  After initial calculation btn is disabled until a value is changed
-    roundFormGroup.valueChanges.subscribe(value => {
-      if(value && value.userRoundScore !== null && this.calcBtnDisabled) {
-          this.calcBtnDisabled = false;
-      }
-    });
-    
-    // calculate score differential whenever status changes
-    roundFormGroup.statusChanges.subscribe(status => {
+    roundFormGroup.valueChanges.subscribe(control => {
+      if(control && control.userRoundScore !== null && this.calcBtnDisabled) {
+        this.calcBtnDisabled = false;
+       }
       this.calcScoreDifferential();
     });
   
     return roundFormGroup;
+  }
+
+  // used to dynamically set validation for user round input based on radio button selection
+  handleUserRoundScoreOnRoundSelectionChange(roundSelected: number | null, index: number) {
+    const userRoundScoreFormControl = this.roundInputsArray.controls[index].get('userRoundScore')
+
+    // on radio btn change, clear out the value for user round score
+    userRoundScoreFormControl?.setValue(null)
+
+    if (this.calcBtnDisabled === false) {
+      this.calcBtnDisabled = true
+    }
+
+    let roundSelectionValue: number = 0;
+    if (roundSelected != null) {
+      roundSelectionValue = roundSelected
+    }
+
+    userRoundScoreFormControl?.enable();
+    userRoundScoreFormControl?.setValidators([
+      Validators.required,
+      Validators.min(roundSelectionValue),
+      this.roundInputValidation(roundSelectionValue)
+    ]);
+    
+    // onlySelf is an optional parameter which only runs updateValueAndValidity for this specific control
+    // since we are only setting validators for userRoundScore we only need to update validation runs for this control
+    userRoundScoreFormControl?.updateValueAndValidity({ onlySelf: true });
   }
 
   calcScoreDifferential() {
@@ -140,12 +142,12 @@ export class RoundInputComponent implements OnInit {
 
   addRound() {
     if (this.roundInputsArray.length < 20) {
-      this.roundInputsArray.push(this.buildRoundForm())
+      this.roundInputsArray.push(this.buildRoundForm(this.roundInputsArrayIndex))
+      this.roundInputsArrayIndex++;
       this.roundTotal.push(0)
     } else {
       alert('Maximum of 20 rounds allowed');
     }
-
   }
 
   removeRound() {
@@ -156,15 +158,17 @@ export class RoundInputComponent implements OnInit {
       alert('Minimum of 3 rounds are required');
     }
     this.calcBtnDisabled = false;
+    this.roundInputsArrayIndex--;
   }
 
   resetAllRounds() {
     this.roundForm.reset()
     // re-binding the formGroup will re-set the form array and the number of formControls back to it's default of 3
     this.roundForm = this.fb.group({
-      roundInputsArray: this.fb.array([ this.buildRoundForm(), this.buildRoundForm(), this.buildRoundForm() ])
+      roundInputsArray: this.fb.array([ this.buildRoundForm(0), this.buildRoundForm(1), this.buildRoundForm(2) ])
     })
     this.handicapIndex = 0;
+    this.roundInputsArrayIndex = 3;
   }
 
 }

--- a/src/app/round-input/round-input.component.ts
+++ b/src/app/round-input/round-input.component.ts
@@ -36,12 +36,9 @@ export class RoundInputComponent implements OnInit {
   buildRoundForm(index: number) : FormGroup {
     const roundFormGroup = this.fb.group({
       userRoundScore: [
-        {
-          value: null, disabled: true
-        },
-        {
-        updateOn: 'change'
-      }],
+        { value: null, disabled: true },
+        { updateOn: 'change' }
+      ],
       courseRating: [67.5, [Validators.required]],
       slopeRating: [117, [Validators.required]],
       roundSelectionGroup: this.fb.group({
@@ -54,7 +51,7 @@ export class RoundInputComponent implements OnInit {
     });
   
     roundFormGroup.valueChanges.subscribe(control => {
-      if(control && control.userRoundScore !== null && this.calcBtnDisabled) {
+      if (control && control.userRoundScore !== null && this.calcBtnDisabled) {
         this.calcBtnDisabled = false;
        }
       this.calcScoreDifferential();
@@ -141,6 +138,7 @@ export class RoundInputComponent implements OnInit {
   }  
 
   addRound() {
+    // tweak below because it won't be based off number of rounds but number of holes played
     if (this.roundInputsArray.length < 20) {
       this.roundInputsArray.push(this.buildRoundForm(this.roundInputsArrayIndex))
       this.roundInputsArrayIndex++;


### PR DESCRIPTION
Refactor buildForm method so that majority of the logic in the observable is moved to another method.  This is primarily for the roundSelection value change so whenever that observable fires it calls another method that handles all the logic and that gets the round selection value along with the formGroup index position.  Kept the logic for the roundForm.valueChange because it was only a few lines and didn't make sense to move it to another method

Adjusted the way the roundSelection is setup, that is now its own formGroup.  This was done as when formGroup value change was firing for round selection in console it was firing twice, once for one radio button being unselected and again for another radio button being selected.  Now I subscribe to the roundSelection formGroup and it only fires ones for the group and not twice like the prior scenario

Removed eighteenHoleMin because I no longer set userRoundSelection validation on page load since on page load it is disabled.  Once a round selection takes place the userRoundScore becomes enabled and all validation takes place which includes setting the min value required for whatever round selection is made

Added variable to track formGroup index position in formArray.  Now when calling buildForm method we pass in an index value which can be used to track the specific formGroup position in the formArray so specific logic can apply to specific formGroups

Minor spacing/formatting of code adjustments along with added/adjusted comments